### PR TITLE
feat!: accept ArrayBuffer, return plain Uint8Array

### DIFF
--- a/__tests__/compare.js
+++ b/__tests__/compare.js
@@ -5,7 +5,7 @@ describe('compare with Node.js impl', () => {
   it('TextEncoder', () => {
     for (const x of ['one', '∀x']) {
       const node = new nodeTextEncoder().encode(x)
-      expect(new Uint8Array(new TextEncoder().encode(x))).toEqual(node)
+      expect(new TextEncoder().encode(x)).toEqual(node)
     }
   })
 
@@ -26,6 +26,16 @@ describe('compare with Node.js impl', () => {
         expect(new nodeTextDecoder(encoding).decode(arr)).toEqual(x)
         expect(new TextDecoder(encoding).decode(arr)).toEqual(x)
       }
+    }
+  })
+
+  it('TextDecoder: accept ArrayBuffer', () => {
+    for (const x of ['one', '∀x']) {
+      const arr = new nodeTextEncoder().encode(x)
+      const buf = arr.buffer
+      expect(buf.byteLength).toBe(arr.length)
+      expect(new nodeTextDecoder().decode(buf)).toEqual(x)
+      expect(new TextDecoder().decode(buf)).toEqual(x)
     }
   })
 })


### PR DESCRIPTION
Depends on #17 

Return value might be pooled in Node.js

This is a semver-major change due to not returning Buffer instances anymore. Also does not fall back to global TextEncoder/TextDecoder if available, so it always returned Buffer instances.

Can also add a fallback to global TextEncoder / TextDecoder while we are here (in a separate PR)